### PR TITLE
UPDATE requirements to not include @dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,12 @@
     "type": "silverstripe-vendormodule",
     "license": "BSD-3-Clause",
     "require": {
-        "dnadesign/silverstripe-elemental": "^4@dev",
-        "dynamic/silverstripe-elemental-baseobject": "^2@dev",
-        "silverstripe/recipe-cms": "^4@dev",
-        "silverstripe/vendor-plugin": "^1@dev"
+        "dnadesign/silverstripe-elemental": "^4.0",
+        "dynamic/silverstripe-elemental-baseobject": "^2.0",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "^5.7",
+        "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "*"
     },
     "config": {


### PR DESCRIPTION
- Update `phpunit/PHPUnit` to `phpunit/phpunit`
- Remove reference to `silverstripe/recipe-cms` as this should be handled by `dnadesign/silverstripe-elemental`

resolves #11