### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [dynamic]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Silverstripe Elemental Gallery
 
+[![Sponsors](https://img.shields.io/badge/Sponsor-Dynamic-ff69b4?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/dynamic)
+
 [![CI](https://github.com/dynamic/silverstripe-elemental-gallery/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-gallery/actions/workflows/ci.yml)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-gallery/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-gallery)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Silverstripe Elemental Gallery
 
-[![Sponsors](https://img.shields.io/badge/Sponsor-Dynamic-ff69b4?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/dynamic)
-
 [![CI](https://github.com/dynamic/silverstripe-elemental-gallery/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamic/silverstripe-elemental-gallery/actions/workflows/ci.yml)
+[![Sponsors](https://img.shields.io/badge/Sponsor-Dynamic-ff69b4?logo=github-sponsors&logoColor=white)](https://github.com/sponsors/dynamic)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-gallery/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-gallery)
 [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-elemental-gallery/downloads)](https://packagist.org/packages/dynamic/silverstripe-elemental-gallery)

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,12 @@
             "homepage": "https://www.dynamicagency.com"
         }
     ],
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/dynamic"
+        }
+    ],
     "require": {
         "php": "^8.3",
         "dnadesign/silverstripe-elemental": "^6",


### PR DESCRIPTION
This PR adds GitHub Sponsors support to make it easier for users to support our open source work.

## Changes
- Added `.github/FUNDING.yml` to enable the GitHub Sponsors button in the repository header
- Added GitHub Sponsors badge to README for better visibility
- Points to [@dynamic](https://github.com/sponsors/dynamic) organization sponsors page

## Benefits
- Provides multiple touchpoints for GitHub Sponsors visibility
- Makes it easier for users to support the project
- Aligns with other Dynamic repositories

The badge will appear at the top of the README alongside existing CI/quality badges.