### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementPhotoGallery.php
+++ b/src/Elements/ElementPhotoGallery.php
@@ -26,12 +26,12 @@ class ElementPhotoGallery extends BaseElement
     /**
      * @return string
      */
-    private static $singular_name = 'Photo Gallery Element';
+    private static $singular_name = 'Photo Gallery';
 
     /**
      * @return string
      */
-    private static $plural_name = 'Photo Gallery Elements';
+    private static $plural_name = 'Photo Gallery Blocks';
 
     /**
      * @var string
@@ -149,13 +149,5 @@ class ElementPhotoGallery extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__.'.BlockType', 'Photo Gallery');
     }
 }


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementPhotoGallery`
- Updated `$singular_name` from `'Photo Gallery Element'` to `'Photo Gallery'`
- Updated `$plural_name` from `'Photo Gallery Elements'` to `'Photo Gallery Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #39

Related: dynamic/silverstripe-essentials-tools#68