### PR TITLE
Merge SS5 branch (5) into SS6 branch (6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,4 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      phpcoverage: true
+    

--- a/src/Elements/ElementPhotoGallery.php
+++ b/src/Elements/ElementPhotoGallery.php
@@ -60,6 +60,20 @@ class ElementPhotoGallery extends BaseElement
     ];
 
     /**
+     * @var array
+     */
+    private static $cascade_deletes = [
+        'Images',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $cascade_duplicates = [
+        'Images',
+    ];
+
+    /**
      * @var bool
      */
     private static $inline_editable = false;

--- a/src/Elements/ElementPhotoGallery.php
+++ b/src/Elements/ElementPhotoGallery.php
@@ -26,12 +26,12 @@ class ElementPhotoGallery extends BaseElement
     /**
      * @return string
      */
-    private static $singular_name = 'Photo Gallery Element';
+    private static $singular_name = 'Photo Gallery';
 
     /**
      * @return string
      */
-    private static $plural_name = 'Photo Gallery Elements';
+    private static $plural_name = 'Photo Gallery Blocks';
 
     /**
      * @var string
@@ -149,13 +149,5 @@ class ElementPhotoGallery extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__.'.BlockType', 'Photo Gallery');
     }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`

## Related

- Original SS5 PR: #40
- Parent issue: dynamic/silverstripe-essentials-tools#68